### PR TITLE
Fix broken build config and mobile performance/leak bugs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,8 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
@@ -31,45 +32,35 @@ android {
 dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'com.google.firebase:firebase-auth:21.0.1'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation files('C:\\Users\\LENOVO\\AndroidStudioProjects\\Mumo\\app\\libs\\spotify-app-remote-release-0.7.2')
-    implementation files('C:\\Users\\LENOVO\\AndroidStudioProjects\\Mumo\\app\\libs\\spotify-app-remote-release-0.7.2.aar')
-    implementation 'com.google.firebase:firebase-database:20.0.1'
+    implementation 'androidx.fragment:fragment:1.3.6'
+    implementation 'androidx.cardview:cardview:1.0.0'
+    implementation 'androidx.browser:browser:1.0.0'
+    implementation 'androidx.viewpager2:viewpager2:1.0.0'
+
+    implementation platform('com.google.firebase:firebase-bom:28.4.0')
+    implementation 'com.google.firebase:firebase-auth'
+    implementation 'com.google.firebase:firebase-database'
+    implementation 'com.google.firebase:firebase-messaging'
+    implementation 'com.google.firebase:firebase-analytics'
+    implementation 'com.google.android.gms:play-services-auth:19.2.0'
+
+    implementation project(':spotify-app-remote')
+    implementation 'com.spotify.android:auth:1.2.5'
+
+    def lottieVersion = "4.1.0"
+    implementation "com.airbnb.android:lottie:$lottieVersion"
+    implementation 'io.ak1:bubbletabbar:1.0.8'
+    implementation 'com.squareup.picasso:picasso:2.71828'
+    implementation 'de.hdodenhof:circleimageview:3.1.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
+    implementation 'com.google.code.gson:gson:2.8.9'
+    implementation 'com.android.volley:volley:1.1.1'
+
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-    implementation 'com.google.android.gms:play-services-auth:19.2.0'
-    implementation platform('com.google.firebase:firebase-bom:28.4.0')
-    def lottieVersion = "4.1.0"
-    implementation "com.airbnb.android:lottie:$lottieVersion"
-    implementation  'io.ak1:bubbletabbar:1.0.8'
-    implementation "androidx.fragment:fragment:1.3.6"
-    implementation 'com.squareup.picasso:picasso:2.71828'
-    implementation 'androidx.appcompat:appcompat:1.3.0-beta01'
-    implementation 'androidx.cardview:cardview:1.0.0'
-    implementation "com.spotify.android:auth:1.2.5"
-    implementation 'com.android.support:multidex:1.0.3'
-    implementation("com.squareup.okhttp3:okhttp:4.9.0")
-    implementation 'com.google.code.gson:gson:2.8.9'
-    //implementation files('../libs/spotify-app-remote-release-0.7.2.aar')
-    //implementation files('../libs/spotify-app-remote-release-0.7.2.aar')
-    //implementation project(':spotify-app-remote')
-    implementation "com.google.code.gson:gson:2.8.6"
-    implementation 'com.android.volley:volley:1.1.1'
-    implementation project(':spotify-app-remote')
-    implementation 'androidx.browser:browser:1.0.0'
-    implementation "androidx.viewpager2:viewpager2:1.0.0"
-    implementation 'com.google.android.material:material:1.5.0-alpha04'
-    implementation 'com.google.firebase:firebase-messaging'
-    implementation 'com.google.firebase:firebase-analytics'
-    implementation 'com.google.firebase:firebase-database'
-    implementation 'de.hdodenhof:circleimageview:3.1.0'
-
-
-
 
 
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,12 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Gson deserializes network responses via reflection using field names/annotations,
+# so the model classes and their signatures/annotations must survive shrinking.
+-keepattributes Signature
+-keepattributes *Annotation*
+-keep class com.venumadhav.mumo.network.** { *; }
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer

--- a/app/src/main/java/com/venumadhav/mumo/chat/Chat.java
+++ b/app/src/main/java/com/venumadhav/mumo/chat/Chat.java
@@ -85,7 +85,7 @@ public class Chat extends AppCompatActivity {
         getUserMobile = MemoryData.getData(Chat.this);
 
         nameTV.setText(getName);
-        Picasso.get().load(getProfilePic).into(profilePic);
+        Picasso.get().load(getProfilePic).fit().into(profilePic);
 
         chattingRecyclerView.setHasFixedSize(true);
         chattingRecyclerView.setLayoutManager(new LinearLayoutManager(Chat.this));

--- a/app/src/main/java/com/venumadhav/mumo/chat/ChatAdapter.java
+++ b/app/src/main/java/com/venumadhav/mumo/chat/ChatAdapter.java
@@ -38,7 +38,7 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MyViewHolder> 
     @NonNull
     @Override
     public ChatAdapter.MyViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        return new MyViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.chat_adapter_layout, null));
+        return new MyViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.chat_adapter_layout, parent, false));
     }
 
 

--- a/app/src/main/java/com/venumadhav/mumo/messages/MessagesAdapter.java
+++ b/app/src/main/java/com/venumadhav/mumo/messages/MessagesAdapter.java
@@ -34,7 +34,7 @@ public class MessagesAdapter extends RecyclerView.Adapter<MessagesAdapter.MyView
     @NonNull
     @Override
     public MessagesAdapter.MyViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        return new MyViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.messages_adapter_layout, null));
+        return new MyViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.messages_adapter_layout, parent, false));
     }
 
     @Override
@@ -43,7 +43,7 @@ public class MessagesAdapter extends RecyclerView.Adapter<MessagesAdapter.MyView
         MessagesList list2 = messagesLists.get(position);
 
         if(!list2.getProfilePic().isEmpty()){
-            Picasso.get().load(list2.getProfilePic()).into(holder.profilePic);
+            Picasso.get().load(list2.getProfilePic()).fit().into(holder.profilePic);
         }
 
         holder.name.setText(list2.getName());

--- a/app/src/main/java/com/venumadhav/mumo/mood.java
+++ b/app/src/main/java/com/venumadhav/mumo/mood.java
@@ -88,14 +88,13 @@ public class mood extends Fragment {
     // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
     private static final String CLIENT_ID = "100d90984cc142febb47cdc0994d4e1a";
     private static final String REDIRECT_URI = "http://com.venumadhav.mumo/callback";
-    private SpotifyAppRemote mSpotifyAppRemote;
     private static final String BUNDLE_RECYCLER_LAYOUT = "mood.recentlyplayedrecyler.layout";
     private boolean dataSet = false;
     private FirebaseAuth mAuth;
     private BottomSheetBehavior bottomSheetBehavior;
     private BubbleTabBar bubbleTabBar;
     static String test="haihello";
-    static String myemail = FirebaseAuth.getInstance().getCurrentUser().getEmail();
+    static String myemail = "";
     private RecentlyplayedAdapter recentlyplayedAdapter;
     private RecyclerView recentlyplayedrecyler;
     private final List<RecentlyplayedList> recentlyplayedLists = new ArrayList<>();
@@ -179,8 +178,8 @@ public class mood extends Fragment {
             String personEmail = acct.getEmail();
             String personId = acct.getId();
             Uri personPhoto = acct.getPhotoUrl();
-            Picasso.get().load(personPhoto).into(dp);
-            Picasso.get().load(personPhoto).into(dp2);
+            Picasso.get().load(personPhoto).fit().into(dp);
+            Picasso.get().load(personPhoto).fit().into(dp2);
             namepop.setText(personName);
             emailpop.setText(personEmail);
             tv.setText(getTimeofday()+" "+personGivenName+" !");
@@ -342,9 +341,6 @@ public class mood extends Fragment {
     @Override
     public void onDestroy() {
         super.onDestroy();
-        if(mSpotifyAppRemote.isConnected()){
-            SpotifyAppRemote.disconnect(mSpotifyAppRemote);
-        }
     }
 
     @Override

--- a/app/src/main/java/com/venumadhav/mumo/musiclist.java
+++ b/app/src/main/java/com/venumadhav/mumo/musiclist.java
@@ -8,6 +8,7 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -68,19 +69,19 @@ public class musiclist extends Fragment {
     // TODO: Rename parameter arguments, choose names that match
     // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
     public  static SpotifyAppRemote mSpotifyAppRemote;
-    Handler handler  = new Handler();
+    Handler handler = new Handler(Looper.getMainLooper());
     Runnable runnable;
     private static final String CLIENT_ID = "100d90984cc142febb47cdc0994d4e1a";
     private static final String REDIRECT_URI = "http://com.venumadhav.mumo/callback";
-    private static CircleImageView playerpic;
-    private static TextView trackname;
-    private static TextView artist;
-    private static Button playpause;
-    private static Button seekforward10;
-    private static Button seekback10;
-    private static Button seeknext;
-    private static Button seekback;
-    private static SeekBar seekBar;
+    private CircleImageView playerpic;
+    private TextView trackname;
+    private TextView artist;
+    private Button playpause;
+    private Button seekforward10;
+    private Button seekback10;
+    private Button seeknext;
+    private Button seekback;
+    private SeekBar seekBar;
     private Button viewinSpotify;
     private TextView runtime;
     private TextView runningtime;
@@ -252,7 +253,7 @@ public class musiclist extends Fragment {
                                    settofirebase("https://i.scdn.co/image/"+track.imageUri.toString().substring(22, track.imageUri.toString().length() - 2),track.name);
                                }
 
-                           Picasso.get().load("https://i.scdn.co/image/"+track.imageUri.toString().substring(22, track.imageUri.toString().length() - 2)).into(playerpic);
+                           Picasso.get().load("https://i.scdn.co/image/"+track.imageUri.toString().substring(22, track.imageUri.toString().length() - 2)).fit().into(playerpic);
                            playerpic.startAnimation(AnimationUtils.loadAnimation(getContext(), R.anim.layouttransit));
                            imurimap.put(im.toString(),1);
 
@@ -378,6 +379,17 @@ public class musiclist extends Fragment {
     @Override
     public void onPause() {
         super.onPause();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        if (runnable != null) {
+            handler.removeCallbacks(runnable);
+        }
+        if (mSpotifyAppRemote != null && mSpotifyAppRemote.isConnected()) {
+            SpotifyAppRemote.disconnect(mSpotifyAppRemote);
+        }
     }
 
     public static void buttonEffect(View button){

--- a/app/src/main/java/com/venumadhav/mumo/recentlyplayed/RecentlyplayedAdapter.java
+++ b/app/src/main/java/com/venumadhav/mumo/recentlyplayed/RecentlyplayedAdapter.java
@@ -34,14 +34,14 @@ public class RecentlyplayedAdapter extends RecyclerView.Adapter<RecentlyplayedAd
     @NonNull
     @Override
     public RecentlyplayedAdapter.MyViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-      return new RecentlyplayedAdapter.MyViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.lastplayed_adapter_layout, null));
+      return new RecentlyplayedAdapter.MyViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.lastplayed_adapter_layout, parent, false));
     }
 
     @Override
     public void onBindViewHolder(@NonNull RecentlyplayedAdapter.MyViewHolder holder, int position) {
         RecentlyplayedList list2 = recentlyplayedlists.get(position);
         if(!list2.getUri().isEmpty()){
-            Picasso.get().load(list2.getUri()).into(holder.imginsiderec);
+            Picasso.get().load(list2.getUri()).fit().into(holder.imginsiderec);
         }
         setAnimation(holder.itemView, position);
     }

--- a/app/src/main/java/com/venumadhav/mumo/userprofile.java
+++ b/app/src/main/java/com/venumadhav/mumo/userprofile.java
@@ -157,7 +157,7 @@ public class userprofile extends Fragment {
 
 //
                 final String profilepicUrl = snapshot.child("users").child(mobile).child("profile_pic").getValue(String.class);
-                Picasso.get().load(profilepicUrl).into(userProfilePic);
+                Picasso.get().load(profilepicUrl).fit().into(userProfilePic);
                     progressDialog.dismiss();
 //
             }

--- a/spotify-app-remote/build.gradle
+++ b/spotify-app-remote/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.google.android.material:material:1.4.0'
-    implementation files('C:\\Users\\LENOVO\\AndroidStudioProjects\\Mumo\\app\\libs\\spotify-app-remote-release-0.7.2.aar')
+    api files('../app/libs/spotify-app-remote-release-0.7.2.aar')
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'


### PR DESCRIPTION
- Remove hardcoded Windows absolute paths from app/build.gradle and
  spotify-app-remote/build.gradle that broke the build on any other
  machine; wire the aar through the spotify-app-remote module via api().
- Dedupe conflicting dependency versions (appcompat, material, gson)
  and drop the unused legacy support/multidex libs (minSdk 21 doesn't
  need them).
- Enable minifyEnabled/shrinkResources for release builds with Gson
  keep rules so network model classes survive shrinking.
- Fix RecyclerView adapters (Chat/Messages/Recentlyplayed) inflating
  item views with a null parent, which drops the root layout params.
- Fix mood.java: onDestroy() dereferenced an always-null
  SpotifyAppRemote field, crashing on every fragment teardown; also
  replaced a static field initializer that call Firebase before a
  user is guaranteed to be signed in.
- Fix musiclist.java: the playback-position polling Handler never
  stopped and the Spotify App Remote connection was never
  disconnected; added onDestroyView() cleanup and switched
  view fields from static to instance to avoid leaking Views.
- Downsample images via Picasso's fit() at all active load sites to
  cut bitmap memory use on mobile devices.